### PR TITLE
[feat] compatibility with heterogeneous objects

### DIFF
--- a/json_to_txt.js
+++ b/json_to_txt.js
@@ -2,11 +2,16 @@ const fs = require("fs");
 const { getStartPoints, getRows, getData } = require("./src/lib.js");
 
 const main = function (params) {
-  const data = getData(params, fs);
-  const headers = Object.keys(data[0]);
-  const startPoints = getStartPoints(data, headers);
-  const rows = getRows(data, headers, startPoints);
-  return rows.join("\n");
-};
+    const data = getData(params, fs);
+    const groups = Array.from(new Set(data.map(item => Object.keys(item).toString())));
+    return groups
+        .map(group => {
+            const groupData = data.filter(item => Object.keys(item).toString() === group);
+            const headers = Object.keys(groupData[0]);
+            const startPoints = getStartPoints(groupData, headers);
+            const rows = getRows(groupData, headers, startPoints);
+            return rows.join('\n');
+        }).join('\n');
+}
 
 module.exports = main;


### PR DESCRIPTION
Quick explanation: currently the lib only works with objects that have the same set of keys. To solve this problem, I grouped the objects according to their keys before generating the rows with getRows.